### PR TITLE
New init-script

### DIFF
--- a/init
+++ b/init
@@ -1,18 +1,21 @@
 #! /bin/sh
-
+#
+# /etc/init.d/pancake
+#
+# Author: Jan Erik Petersen <Marco01_809@web.de>
+# Requires Pancake 1.3 or newer
+#
 ### BEGIN INIT INFO
 # Provides:          pancake
-# Required-Start:    $all
-# Required-Stop:     $all
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: Pancake
 # Description:       Pancake HTTP Server
 ### END INIT INFO
 
-# Author: Jan Erik Petersen <Marco01_809@web.de>
-# Requires Pancake 1.3 or newer
-
+# PATH should only include /usr/* if it runs after the mountnfs.sh script
 PATH=/sbin:/usr/local/sbin:/usr/sbin:/bin:/usr/local/bin:/usr/bin
 
 DESC="Pancake HTTP Server"
@@ -24,138 +27,115 @@ SCRIPTNAME=/etc/init.d/$NAME
 DAEMON=/usr/local/Pancake/sys/pancake.sh
 DAEMON_ARGS="--daemon --pidfile=$PIDFILE"
 
-STOP_WAIT_SECS=30
-
-# Exit if the package is not installed
-[ -x "$DAEMON" ] || exit 0
-
 # Read configuration variable file if it is present
 [ -r /etc/default/$NAME ] && . /etc/default/$NAME
 
-# 0 -> Process running ($PIDFILE exists)
-# 1 -> Process not running, $PIDFILE doesn't exist
-# 2 -> Process not running, $PIDFILE exists
-get_status() {
-        [ ! -r $PIDFILE ] && return 1
-        PID=`cat $PIDFILE`
-        kill -0 $PID >/dev/null 2>/dev/null
-        [ $? = 0 ] && return 0 || return 2
+# Exit if the package is not installed
+[ -x "$DAEMON" ] || exit 5
+
+# Load the VERBOSE setting and other rcS variables
+. /lib/init/vars.sh
+
+# Define LSB log_* functions.
+. /lib/lsb/init-functions
+
+# Return
+#   0 if daemon is running
+#   1 if daemon is not running and the pid file exists
+#   3 if daemon is not running
+#   4 if unable to determine status
+get_status()
+{
+        start-stop-daemon --quiet --pidfile $PIDFILE --status
 }
 
-# 0 -> Process started successfully
-# 1 -> Process was running
-# 2 -> Couldn't start process
-do_start() {
-        get_status
-        [ $? = 0 ] && return 1
-
-        $DAEMON $DAEMON_ARGS >/dev/null
-        [ $? = 0 ] && return 0 || return 2
+# Return
+#   0 if daemon has been started
+#   1 if daemon was already running
+#   2 if daemon could not be started
+do_start()
+{
+        get_status && return 1
+        $DAEMON $DAEMON_ARGS >/dev/null || return 2
 }
 
-# 0 -> Process stopped successfully
-# 1 -> Process wasn't running
-# 2 -> Couldn't stop process
-do_stop() {
-        get_status
-        [ $? != 0 ] && return 1
-
-        kill -TERM $PID
-        [ $? != 0 ] && return 2
-
-        local tries=0
-        while [ $tries -lt $STOP_WAIT_SECS ]; do
-                sleep 1
-                get_status
-                if [ $? != 0 ]; then
-                        rm -f $PIDFILE
-                        return 0
-                fi
-                tries=$((tries+1))
-        done
-
-        kill -KILL $PID
-        [ $? != 0 ] && return 2
-        sleep 2
-
-        get_status
-        if [ $? != 0 ]; then
-                rm -f $PIDFILE
-                return 0
-        fi
-        return 2
+# Return
+#   0 if daemon has been stopped
+#   1 if daemon was already stopped
+#   2 if daemon could not be stopped
+do_stop()
+{
+        get_status || return 1
+        start-stop-daemon --quiet --pidfile $PIDFILE --stop --retry=TERM/30/KILL/5 || return 2
+        rm -f $PIDFILE
+        return 0
 }
 
-# 0 -> SIGHUP sent successfully
-# 1 -> Process wasn't running
-# 2 -> Couldn't send SIGHUP
-do_reload() {
-        get_status
-        [ $? != 0 ] && return 1
-
-        kill -1 $PID >/dev/null 2>/dev/null
-        [ $? = 0 ] && return 0 || return 2
+# Return
+#   0 if SIGHUP was sent
+#   1 if daemon was not running
+#   2 if sending SIGHUP failed
+do_reload()
+{
+        get_status || return 1
+        start-stop-daemon --quiet --pidfile $PIDFILE --stop --signal HUP || return 2
 }
 
 case "$1" in
-        start)
-                echo -n "Starting $DESC: "
+  start)
+        log_daemon_msg "Starting $DESC" "$NAME"
+        do_start
+        case "$?" in
+                0|1) log_end_msg 0 ;;
+                *) log_end_msg 1 ;;
+        esac
+        ;;
+  stop)
+        log_daemon_msg "Stopping $DESC" "$NAME"
+        do_stop
+        case "$?" in
+                0|1) log_end_msg 0 ;;
+                *) log_end_msg 1 ;;
+        esac
+        ;;
+  status)
+        get_status
+        status=$?
+        case "$status" in
+                0) log_action_msg "$DESC is running with PID `cat $PIDFILE`" ;;
+                1) log_action_msg "$DESC is not running, but $PIDFILE still exists" ;;
+                3) log_action_msg "$DESC is not running" ;;
+                *) log_failure_msg "Unable to determine status of $DESC" ;;
+        esac
+        exit $status
+        ;;
+  reload)
+        log_daemon_msg "Reloading $DESC" "$NAME"
+        do_reload
+        case "$?" in
+                0) log_end_msg 0 ;;
+                1) log_end_msg 1; exit 7 ;;
+                *) log_end_msg 1 ;;
+        esac
+        ;;
+  restart|force-reload)
+        log_daemon_msg "Restarting $DESC" "$NAME"
+        do_stop
+        case "$?" in
+          0|1)
                 do_start
-                status=$?
-                [ $status = 0 ] && echo "$NAME."
-                [ $status = 1 ] && echo "ERROR: $NAME is already running."
-                [ $status = 2 ] && echo "ERROR: Couldn't start $NAME."
-                exit $status
-                ;;
-        stop)
-                echo -n "Stopping $DESC: "
-                do_stop
-                status=$?
-                [ $status = 0 ] && echo "$NAME."
-                [ $status = 1 ] && echo "ERROR: $NAME is not running."
-                [ $status = 2 ] && echo "ERROR: Couldn't stop $NAME."
-                exit $status
-                ;;
-        restart|force-reload)
-                echo -n "Restarting $DESC: "
-                do_stop
-                status=$?
-                [ $status = 1 ] && echo -n "WARNING: $NAME was not running: "
-                [ $status = 2 ] && echo "ERROR: Couldn't stop $NAME." && exit 2
-                do_start
-                status=$?
-                [ $status = 0 ] && echo "$NAME."
-                [ $status = 1 ] && echo "ERROR: $NAME is already running."
-                [ $status = 2 ] && echo "ERROR: Couldn't start $NAME."
-                exit $status
-                ;;
-        reload)
-                echo -n "Reloading $DESC: "
-                do_reload
-                status=$?
-                [ $status = 0 ] && echo "$NAME."
-                [ $status = 1 ] && echo "ERROR: $NAME is not running."
-                [ $status = 2 ] && echo "ERROR: Couldn't reload $NAME."
-                exit $status
-                ;;
-        status)
-                get_status
-                status=$?
-                case "$status" in
-                        0)
-                                echo "$DESC is running. PID: $PID"
-                                ;;
-                        1)
-                                echo "$DESC is not running"
-                                ;;
-                        2)
-                                echo "$DESC is not running, but $PIDFILE still exists"
-                                ;;
+                case "$?" in
+                        0) log_end_msg 0 ;;
+                        *) log_end_msg 1 ;;
                 esac
-                exit $status
                 ;;
-        *)
-                echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload|status}"
-                exit 3
+          *)
+                log_end_msg 1
                 ;;
+        esac
+        ;;
+  *)
+        echo "Usage: $SCRIPTNAME {start|stop|status|restart|reload|force-reload}" >&2
+        exit 3
+        ;;
 esac


### PR DESCRIPTION
- Use the log_\* functions provided by /lib/lsb/init-functions (Allows message formatting by the system)
- Compliant with http://refspecs.linuxfoundation.org/LSB_4.1.0/LSB-Core-generic/LSB-Core-generic/iniscrptact.html
- Use start-stop-daemon for get_status(), do_stop() and do_reload() (not needed for do_start())

To make sure /lib/lsb/init-functions and start-stop-daemon exist, depend on lsb-base.

Example output on Debian wheezy:

``` bash
marco@debian~ $ sudo /etc/init.d/pancake start
[ ok ] Starting Pancake HTTP Server: pancake.
marco@debian~ $ sudo /etc/init.d/pancake status
[info] Pancake HTTP Server is running with PID 9094.
marco@debian~ $ sudo /etc/init.d/pancake reload
[ ok ] Reloading Pancake HTTP Server: pancake.
marco@debian~ $ sudo /etc/init.d/pancake stop
[ ok ] Stopping Pancake HTTP Server: pancake.
marco@debian~ $ sudo /etc/init.d/pancake status
[info] Pancake HTTP Server is not running.
marco@debian~ $ sudo /etc/init.d/pancake reload
[FAIL] Reloading Pancake HTTP Server: pancake failed!
```

Signed-off-by: Jan Erik Petersen Marco01_809@web.de
